### PR TITLE
Add suggest to `SearchRequest`

### DIFF
--- a/src/Search/SearchRequest.php
+++ b/src/Search/SearchRequest.php
@@ -27,6 +27,10 @@ final class SearchRequest implements ArrayableInterface
      * @var int
      */
     private $size;
+    /**
+     * @var array
+     */
+    private $suggest;
 
     public function __construct(array $query)
     {
@@ -57,13 +61,19 @@ final class SearchRequest implements ArrayableInterface
         return $this;
     }
 
+    public function setSuggest(array $suggest): self
+    {
+        $this->suggest = $suggest;
+        return $this;
+    }
+
     public function toArray(): array
     {
         $request = [
             'query' => $this->query
         ];
 
-        foreach (['highlight', 'sort', 'from', 'size'] as $property) {
+        foreach (['highlight', 'sort', 'from', 'size', 'suggest'] as $property) {
             if (isset($this->$property)) {
                 $request[$property] = $this->$property;
             }

--- a/tests/Unit/Search/SearchRequestTest.php
+++ b/tests/Unit/Search/SearchRequestTest.php
@@ -41,6 +41,13 @@ final class SearchRequestTest extends TestCase
             '_score'
         ]);
 
+        $request->setSuggest(['by_term' => [
+            'text' => 'foo',
+            'term' => [
+                'field' => 'content',
+            ],
+        ]]);
+
         $request->setFrom(0);
         $request->setSize(10);
 
@@ -58,7 +65,15 @@ final class SearchRequestTest extends TestCase
                 '_score'
             ],
             'from' => 0,
-            'size' => 10
+            'size' => 10,
+            'suggest' => [
+                'by_term' => [
+                    'text' => 'foo',
+                    'term' => [
+                        'field' => 'content',
+                    ],
+                ],
+            ],
         ], $request->toArray());
     }
 }


### PR DESCRIPTION
This commit adds support for the elasticsearch suggesters feature.
[Search Suggestions Docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html)

This is paired with a pull request to the `elastic-scout-driver-plus` extension.