### PR TITLE
Add script_fields support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ $request->setTrackTotalHits(true);
 // track scores
 $request->setTrackScores(true);
 
+// script fields
+$request->setScriptFields([
+    'my_doubled_field' => [
+        'script' => [
+            'lang' => 'painless',
+            'source' => 'doc[params.field] * params.multiplier',
+            'params' => [
+                'field' => 'my_field',
+                'multiplier' => 2,
+            ],
+        ],
+    ],
+]);
+
 // boost indices
 $request->setIndicesBoost([
     ['my-alias' => 1.4],

--- a/src/Search/SearchRequest.php
+++ b/src/Search/SearchRequest.php
@@ -58,6 +58,10 @@ final class SearchRequest implements ArrayableInterface
      * @var bool|null
      */
     private $trackScores;
+    /**
+     * @var array|null
+     */
+    private $scriptFields;
 
     public function __construct(array $query)
     {
@@ -142,6 +146,12 @@ final class SearchRequest implements ArrayableInterface
         return $this;
     }
 
+    public function setScriptFields(array $scriptFields): self
+    {
+        $this->scriptFields = $scriptFields;
+        return $this;
+    }
+
     public function toArray(): array
     {
         $request = [
@@ -161,6 +171,7 @@ final class SearchRequest implements ArrayableInterface
             'trackTotalHits' => 'track_total_hits',
             'indicesBoost' => 'indices_boost',
             'trackScores' => 'track_scores',
+            'scriptFields' => 'script_fields',
         ] as $property => $requestParameter) {
             if (isset($this->$property)) {
                 $request[$requestParameter] = $this->$property;

--- a/tests/Unit/Search/SearchRequestTest.php
+++ b/tests/Unit/Search/SearchRequestTest.php
@@ -296,4 +296,42 @@ final class SearchRequestTest extends TestCase
             'track_scores' => true,
         ], $request->toArray());
     }
+
+    public function test_array_casting_with_script_fields(): void
+    {
+        $request = new SearchRequest([
+            'match_all' => new stdClass(),
+        ]);
+
+        $request->setScriptFields([
+            'my_doubled_field' => [
+                'script' => [
+                    'lang' => 'painless',
+                    'source' => 'doc[params.field] * params.multiplier',
+                    'params' => [
+                        'field' => 'my_field',
+                        'multiplier' => 2,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            'query' => [
+                'match_all' => new stdClass(),
+            ],
+            'script_fields' => [
+                'my_doubled_field' => [
+                    'script' => [
+                        'lang' => 'painless',
+                        'source' => 'doc[params.field] * params.multiplier',
+                        'params' => [
+                            'field' => 'my_field',
+                            'multiplier' => 2,
+                        ],
+                    ],
+                ],
+            ],
+        ], $request->toArray());
+    }
 }


### PR DESCRIPTION
This PR adds support for setting script_fields on a search request.

This is useful for i.e. calculating distance from a reference point to a geo_point field in the index.

The example given in the readme multiplies a given field in each search result with a factor 2.

The Hit class could be extended with a getFields() or getField(string $field) method to obtain the value of a scripted field. But that's outside the scope of this PR.