### PR TITLE
(add): Aggregation and bucket class

### DIFF
--- a/src/Search/Aggregation.php
+++ b/src/Search/Aggregation.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace ElasticAdapter\Search;
+
+final class Aggregation implements SearchResponseRawInterface
+{
+    /**
+     * @var array
+     */
+    private $aggregation;
+
+    public function __construct(array $aggregation)
+    {
+        $this->aggregation = $aggregation;
+    }
+
+    public function getBuckets(): array
+    {
+        return array_map(static function (array $bucket) {
+            return new Bucket($bucket);
+        }, $this->aggregation['buckets'] ?? []);
+    }
+
+    public function getRaw(): array
+    {
+        return $this->aggregation;
+    }
+}

--- a/src/Search/Bucket.php
+++ b/src/Search/Bucket.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace ElasticAdapter\Search;
+
+final class Bucket implements SearchResponseRawInterface
+{
+    /**
+     * @var array
+     */
+    private $bucket;
+
+    public function __construct(array $bucket)
+    {
+        $this->bucket = $bucket;
+    }
+
+    public function getDocCount(): int
+    {
+        return $this->bucket['doc_count'] ?? 0;
+    }
+
+    public function getKey(): string
+    {
+        return $this->bucket['key'];
+    }
+
+    public function getRaw(): array
+    {
+        return $this->bucket;
+    }
+}

--- a/src/Search/SearchResponse.php
+++ b/src/Search/SearchResponse.php
@@ -40,7 +40,9 @@ final class SearchResponse implements SearchResponseRawInterface
 
     public function getAggregations(): array
     {
-        return $this->response['aggregations'] ?? [];
+        return array_map(static function (array $aggregation) {
+            return new Aggregation($aggregation);
+        }, $this->response['aggregations'] ?? []);
     }
 
     public function getRaw(): array

--- a/tests/Unit/Search/SearchResponseTest.php
+++ b/tests/Unit/Search/SearchResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace ElasticAdapter\Tests\Unit\Search;
 
+use ElasticAdapter\Search\Aggregation;
 use ElasticAdapter\Search\Hit;
 use ElasticAdapter\Search\SearchResponse;
 use ElasticAdapter\Search\Suggestion;
@@ -105,11 +106,13 @@ final class SearchResponseTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals([
-            'min_price' => [
+        $aggregation = [
+            'min_price' => new Aggregation([
                 'value' => 10,
-            ],
-        ], $searchResponse->getAggregations());
+            ]),
+        ];
+
+        $this->assertEquals($aggregation, $searchResponse->getAggregations());
     }
 
     public function test_raw_representation_can_be_retrieved(): void


### PR DESCRIPTION
In your package, `getHits` return an array of `Hit` objects.
In your package, `getSuggestions` return an array of `Suggestion` objects.

However, when calling `getAggregations` an ordinary array of arrays is returned.

My PR returns an `Aggregration` object, with inside a `Bucket` object, for better handling of data. It is still in the rough, as Aggregations can have different types of Buckets returned.
