### PR TITLE
 Add custom routing feature for bulk index and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,3 +369,12 @@ $suggestions = $response->getSuggestions();
 // get the aggregations
 $aggregations = $response->getAggregations();
 ```
+
+### Custom routing
+
+Every document can accept a nullable routing key that if not null will be used for bulk index and delete
+operations.
+
+```php
+new ElasticAdapter\Documents\Document('1', ['title' => 'foo'], $routing = '123'),
+```

--- a/src/Documents/Document.php
+++ b/src/Documents/Document.php
@@ -11,19 +11,29 @@ final class Document implements ArrayableInterface
      */
     private $id;
     /**
+     * @var string|null
+     */
+    private $routing;
+    /**
      * @var array
      */
     private $content;
 
-    public function __construct(string $id, array $content)
+    public function __construct(string $id, array $content, ?string $routing = null)
     {
         $this->id = $id;
+        $this->routing = $routing;
         $this->content = $content;
     }
 
     public function getId(): string
     {
         return $this->id;
+    }
+
+    public function getRouting(): ?string
+    {
+        return $this->routing;
     }
 
     public function getContent(): array

--- a/src/Documents/DocumentManager.php
+++ b/src/Documents/DocumentManager.php
@@ -30,7 +30,12 @@ class DocumentManager
         ];
 
         foreach ($documents as $document) {
-            $params['body'][] = ['index' => ['_id' => $document->getId()]];
+            $indexConfig = ['index' => ['_id' => $document->getId()]];
+            if (!is_null($document->getRouting())) {
+                $indexConfig['index']['_routing'] = $document->getRouting();
+            }
+            
+            $params['body'][] = $indexConfig;
             $params['body'][] = $document->getContent();
         }
 
@@ -51,7 +56,11 @@ class DocumentManager
         ];
 
         foreach ($documents as $document) {
-            $params['body'][] = ['delete' => ['_id' => $document->getId()]];
+            $deleteConfig = ['delete' => ['_id' => $document->getId()]];
+            if (!is_null($document->getRouting())) {
+                $deleteConfig['delete']['_routing'] = $document->getRouting();
+            }
+            $params['body'][] = $deleteConfig;
         }
 
         $this->client->bulk($params);

--- a/tests/Unit/Documents/DocumentManagerTest.php
+++ b/tests/Unit/Documents/DocumentManagerTest.php
@@ -79,6 +79,28 @@ final class DocumentManagerTest extends TestCase
         ], false));
     }
 
+    public function test_documents_can_be_indexed_with_custom_routing(): void
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('bulk')
+            ->with([
+                'index' => 'test',
+                'refresh' => 'true',
+                'body' => [
+                    ['index' => ['_id' => '1', 'routing' => '123']],
+                    ['title' => 'Doc 1'],
+                    ['index' => ['_id' => '2']],
+                    ['title' => 'Doc 2'],
+                ],
+            ]);
+
+        $this->assertSame($this->documentManager, $this->documentManager->index('test', [
+            new Document('1', ['title' => 'Doc 1'], '123'),
+            new Document('2', ['title' => 'Doc 2']),
+        ], true));
+    }
+
     public function test_documents_can_be_deleted_with_refresh(): void
     {
         $this->client
@@ -115,6 +137,26 @@ final class DocumentManagerTest extends TestCase
         $this->assertSame($this->documentManager, $this->documentManager->delete('test', [
             new Document('1', ['title' => 'Doc 1']),
         ], false));
+    }
+
+    public function test_documents_can_be_deleted_with_custom_routing(): void
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('bulk')
+            ->with([
+                'index' => 'test',
+                'refresh' => 'true',
+                'body' => [
+                    ['delete' => ['_id' => '1', 'routing' => '123']],
+                    ['delete' => ['_id' => '2']],
+                ],
+            ]);
+
+        $this->assertSame($this->documentManager, $this->documentManager->delete('test', [
+            new Document('1', ['title' => 'Doc 1'], '123'),
+            new Document('2', ['title' => 'Doc 2']),
+        ], true));
     }
 
     public function test_documents_can_be_deleted_by_query_with_refresh(): void

--- a/tests/Unit/Documents/DocumentManagerTest.php
+++ b/tests/Unit/Documents/DocumentManagerTest.php
@@ -88,7 +88,7 @@ final class DocumentManagerTest extends TestCase
                 'index' => 'test',
                 'refresh' => 'true',
                 'body' => [
-                    ['index' => ['_id' => '1', 'routing' => '123']],
+                    ['index' => ['_id' => '1', '_routing' => '123']],
                     ['title' => 'Doc 1'],
                     ['index' => ['_id' => '2']],
                     ['title' => 'Doc 2'],
@@ -148,7 +148,7 @@ final class DocumentManagerTest extends TestCase
                 'index' => 'test',
                 'refresh' => 'true',
                 'body' => [
-                    ['delete' => ['_id' => '1', 'routing' => '123']],
+                    ['delete' => ['_id' => '1', '_routing' => '123']],
                     ['delete' => ['_id' => '2']],
                 ],
             ]);

--- a/tests/Unit/Documents/DocumentTest.php
+++ b/tests/Unit/Documents/DocumentTest.php
@@ -12,10 +12,18 @@ final class DocumentTest extends TestCase
 {
     public function test_document_getters(): void
     {
-        $document = new Document('123456', ['title' => 'foo']);
+        $document = new Document('123456', ['title' => 'foo'], '123');
 
         $this->assertSame('123456', $document->getId());
+        $this->assertSame('123', $document->getRouting());
         $this->assertSame(['title' => 'foo'], $document->getContent());
+    }
+
+    public function test_document_routing_nullable(): void
+    {
+        $document = new Document('123456', ['title' => 'foo']);
+
+        $this->assertSame(null, $document->getRouting());
     }
 
     public function test_array_casting(): void


### PR DESCRIPTION
Add a nullable routing document property that enables for elasticsearch custom routing.
If no routing key is provided or the value is null then routing will not be specified to allow for elasticsearch's defaults.

Related issue https://github.com/babenkoivan/elastic-adapter/issues/8.

This pr will allow for elastic-scout-driver to support custom routing.