### PR TITLE
Add index error handling

### DIFF
--- a/src/Documents/DocumentManager.php
+++ b/src/Documents/DocumentManager.php
@@ -2,7 +2,6 @@
 
 namespace ElasticAdapter\Documents;
 
-use ElasticAdapter\Support\Arr;
 use ElasticAdapter\ElasticException;
 use ElasticAdapter\Search\SearchRequest;
 use ElasticAdapter\Search\SearchResponse;

--- a/src/ElasticException.php
+++ b/src/ElasticException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace ElasticAdapter;
+
+class ElasticException extends \Exception
+{
+}

--- a/src/Indices/IndexManager.php
+++ b/src/Indices/IndexManager.php
@@ -34,14 +34,7 @@ class IndexManager
 
         return $this;
     }
-
-    public function get(string $indexPattern): array
-    {
-        return $this->indices->get([
-            'index' => $indexPattern,
-        ]);
-    }
-
+    
     public function exists(string $indexName): bool
     {
         return $this->indices->exists([

--- a/src/Indices/IndexManager.php
+++ b/src/Indices/IndexManager.php
@@ -35,6 +35,13 @@ class IndexManager
         return $this;
     }
 
+    public function get(string $indexPattern): array
+    {
+        return $this->indices->get([
+            'index' => $indexPattern,
+        ]);
+    }
+
     public function exists(string $indexName): bool
     {
         return $this->indices->exists([

--- a/tests/Unit/Indices/IndexManagerTest.php
+++ b/tests/Unit/Indices/IndexManagerTest.php
@@ -74,27 +74,6 @@ class IndexManagerTest extends TestCase
         $this->assertSame($this->indexManager, $this->indexManager->close($indexName));
     }
 
-    public function test_indexes_can_be_retrieved(): void
-    {
-        $indexPattern = '*';
-
-        $this->indices
-            ->expects($this->once())
-            ->method('get')
-            ->with([
-                'index' => $indexPattern,
-            ])
-            ->willReturn([
-                '.kibana' => ['...'],
-                'index' => ['...'],
-            ]);
-        
-        $this->assertEquals([
-            '.kibana' => ['...'],
-            'index' => ['...'],
-        ], $this->indexManager->get($indexPattern));
-    }
-
     public function test_index_existence_can_be_checked(): void
     {
         $indexName = 'foo';

--- a/tests/Unit/Indices/IndexManagerTest.php
+++ b/tests/Unit/Indices/IndexManagerTest.php
@@ -74,6 +74,27 @@ class IndexManagerTest extends TestCase
         $this->assertSame($this->indexManager, $this->indexManager->close($indexName));
     }
 
+    public function test_indexes_can_be_retrieved(): void
+    {
+        $indexPattern = '*';
+
+        $this->indices
+            ->expects($this->once())
+            ->method('get')
+            ->with([
+                'index' => $indexPattern,
+            ])
+            ->willReturn([
+                '.kibana' => ['...'],
+                'index' => ['...'],
+            ]);
+        
+        $this->assertEquals([
+            '.kibana' => ['...'],
+            'index' => ['...'],
+        ], $this->indexManager->get($indexPattern));
+    }
+
     public function test_index_existence_can_be_checked(): void
     {
         $indexName = 'foo';


### PR DESCRIPTION
### Purpose

This PR adds an exception to be thrown when an index response contains errors.

### Description

I discovered after a couple hours of troubleshooting why my indexing wasn't working with my custom mapping using elastic-migrations. I had to jump into my vendor directory and dump the response ES was replying back with, but unfortunately no errors are handled, logged, or returned.

Without any error handling, I can't use this package in production, as my indexing may suddenly stop working and I won't have any knowledge of its failure without enabling some sort of logging mechanism inside of ElasticSearch itself.

### References

This PR abides by ElasticSearch's outlined response body for bulk operations.

https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html#bulk-api-response-body

---

Let me know if you would like anything adjusted or have any comments/criticisms of this PR. I'm all for abiding by whatever style you would like 👍 

Thanks!