### PR TITLE
Added customize mapping callback and raw mapping class

### DIFF
--- a/src/Indices/IndexManager.php
+++ b/src/Indices/IndexManager.php
@@ -2,6 +2,7 @@
 
 namespace ElasticAdapter\Indices;
 
+use ElasticAdapter\Support\ArrayableInterface;
 use Elasticsearch\Client;
 use Elasticsearch\Namespaces\IndicesNamespace;
 
@@ -64,7 +65,7 @@ class IndexManager
         return $this;
     }
 
-    public function putMapping(string $indexName, Mapping $mapping): self
+    public function putMapping(string $indexName, ArrayableInterface $mapping): self
     {
         $this->indices->putMapping([
             'index' => $indexName,

--- a/src/Indices/Mapping.php
+++ b/src/Indices/Mapping.php
@@ -67,6 +67,14 @@ final class Mapping implements ArrayableInterface
      */
     private $dynamicTemplates = [];
 
+    /**
+     * @var callable|null
+     *
+     * function will receive $mapping array and should return a
+     * customized array that will be used instead.
+     */
+    private $onSerializeCallback = null;
+
     public function enableFieldNames(): self
     {
         $this->isFieldNamesEnabled = true;
@@ -112,6 +120,13 @@ final class Mapping implements ArrayableInterface
         return $this;
     }
 
+    public function setOnBeforeSerializeCallback(callable $callback = null)
+    {
+        $this->onSerializeCallback = $callback;
+
+        return $this;
+    }
+
     public function dynamicTemplate(string $name, array $parameters): self
     {
         $this->dynamicTemplates[] = [$name => $parameters];
@@ -140,6 +155,14 @@ final class Mapping implements ArrayableInterface
 
         if (count($this->dynamicTemplates) > 0) {
             $mapping['dynamic_templates'] = $this->dynamicTemplates;
+        }
+
+        if (is_callable($this->onSerializeCallback)) {
+            $mapping = ($this->onSerializeCallback)($mapping);
+
+            if (!is_array($mapping)) {
+                throw new \InvalidArgumentException('The custom mapping should be an array');
+            }
         }
 
         return $mapping;

--- a/src/Indices/Mapping.php
+++ b/src/Indices/Mapping.php
@@ -161,7 +161,7 @@ final class Mapping implements ArrayableInterface
             $mapping = ($this->onSerializeCallback)($mapping);
 
             if (!is_array($mapping)) {
-                throw new \InvalidArgumentException('The custom mapping should be an array');
+                throw new \UnexpectedValueException('The custom mapping should be an array');
             }
         }
 

--- a/src/Indices/RawMapping.php
+++ b/src/Indices/RawMapping.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace ElasticAdapter\Indices;
+
+use ElasticAdapter\Support\ArrayableInterface;
+
+final class RawMapping implements ArrayableInterface
+{
+    /**
+     * @var array
+     */
+    private $mapping;
+
+    public function __construct(array $mapping)
+    {
+        $this->mapping = $mapping;
+    }
+
+    public function toArray(): array
+    {
+        return $this->mapping;
+    }
+}

--- a/tests/Unit/Indices/MappingTest.php
+++ b/tests/Unit/Indices/MappingTest.php
@@ -4,6 +4,7 @@ namespace ElasticAdapter\Tests\Unit\Indices;
 
 use BadMethodCallException;
 use ElasticAdapter\Indices\Mapping;
+use ElasticAdapter\Indices\RawMapping;
 use ElasticAdapter\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -194,5 +195,20 @@ class MappingTest extends TestCase
             })
             ->text('last_name')
             ->toArray();
+    }
+
+    public function test_raw_mapping(): void
+    {
+        $mappingValue = [
+            'properties' => [
+                'last_name' => [
+                    'type' => 'text'
+                ]
+            ]
+        ];
+
+        $mapping = (new RawMapping($mappingValue));
+
+        $this->assertSame($mappingValue, $mapping->toArray());
     }
 }

--- a/tests/Unit/Indices/MappingTest.php
+++ b/tests/Unit/Indices/MappingTest.php
@@ -136,4 +136,50 @@ class MappingTest extends TestCase
             ],
         ], $mapping->toArray());
     }
+
+    public function test_on_serialize_callback(): void
+    {
+        $mapping = (new Mapping())
+            ->setOnBeforeSerializeCallback(function (array $mapping) {
+                $mapping['dynamic'] = false;
+                $mapping['date_detection'] = false;
+
+                return $mapping;
+            })
+            ->text('last_name')
+            ->toArray();
+
+        $this->assertSame([
+            'properties' => [
+                'last_name' => [
+                    'type' => 'text'
+                ]
+            ],
+            'dynamic' => false,
+            'date_detection' => false
+        ], $mapping);
+    }
+
+    public function test_can_remove_on_serialize_callback(): void
+    {
+        $mapping = (new Mapping())
+            ->setOnBeforeSerializeCallback(function (array $mapping) {
+                $mapping['dynamic'] = false;
+                $mapping['date_detection'] = false;
+
+                return $mapping;
+            })
+            // I changed my mind and don't want a callback anymore
+            ->setOnBeforeSerializeCallback()
+            ->text('last_name')
+            ->toArray();
+
+        $this->assertSame([
+            'properties' => [
+                'last_name' => [
+                    'type' => 'text'
+                ]
+            ]
+        ], $mapping);
+    }
 }

--- a/tests/Unit/Indices/MappingTest.php
+++ b/tests/Unit/Indices/MappingTest.php
@@ -182,4 +182,17 @@ class MappingTest extends TestCase
             ]
         ], $mapping);
     }
+
+    public function test_on_serialize_callback_with_invalid_return(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The custom mapping should be an array');
+
+        (new Mapping())
+            ->setOnBeforeSerializeCallback(function (array $mapping) {
+                return true;
+            })
+            ->text('last_name')
+            ->toArray();
+    }
 }


### PR DESCRIPTION
This fixes https://github.com/babenkoivan/elastic-migrations/issues/31

I implemented two approaches to fix it

## Approach 1 - callback
I have added an optional callback to the `Mapping` class that let's you tap into the mapping array before passing it on. This allows to add any properties we would like to the mapping array. This would allow to set `dynamic` mapping to `false` for example or to disable `date_detection`.

Here is an example usage to do both:

```
$mapping = (new Mapping())
    ->setOnBeforeSerializeCallback(function (array $mapping) {
        $mapping['dynamic'] = false;
        $mapping['date_detection'] = false;

        return $mapping;
    })
   ->text('last_name');
 ```
And this would result in the following mapping array
```
[
    'properties' => [
        'last_name' => [
             'type' => 'text'
         ]
     ],
    'dynamic' => false,
    'date_detection' => false
]
```

## Approach 2 - Raw mapping

I have added another class that only return the array passed to it. You can use it as follow:

```
$mapping = (new RawMapping([
            'properties' => [
                'last_name' => [
                    'type' => 'text'
                ]
            ]
        ]));
```
I have also widened the argument to the following function to allow both `Mapping` and `RawMapping` to work `public function putMapping(string $indexName, ArrayableInterface $mapping): self`

## Moving forward

Some personal thoughts though regarding this (this is meant to be constructive and I do not intend attack the author of the code), is that the `Mapping` class does not provide a lot of benefit. What I mean is that there is a lot of code involved (160 lines in Mapping.php and 200 in MappingTest.php) and in the end the only usage I see of the class is to be used in `\ElasticAdapter\Indices\IndexManager::putMapping` to be dumped with the `toArray()` method.

I understand that there are fancy and neat methods added to the Mapping class, but the problem is that forcing to use fancy magic methods is putting a gate in front of some existing and eventually new features in the mapping array. If possible I would avoid using class and would go only with straight array passed directly to `putMapping`. But there might also be cases that I missed that would invalidate everything I have said though.

I think that if we would remove the `Mapping` and `RawMapping` in favor of an array, it would at the same time increase the flexibility offered by the package and lower the maintenance required by the owners.
