### PR TITLE
Add `search_after` and `pit` options to the search request

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,15 @@ $request->indicesBoost([
 // use pagination
 $request->from(0)->size(20);
 
+// use search after
+$request->searchAfter(['1624169819000']);
+
+// assign a point in time id
+$request->pit([
+    'id' => 'pit_id',
+    'keep_alive' => '1m',
+]);
+
 // execute the search request and get the response
 $response = $documentManager->search('my_index', $request);
 

--- a/src/Search/SearchRequest.php
+++ b/src/Search/SearchRequest.php
@@ -112,6 +112,18 @@ final class SearchRequest implements Arrayable
         return $this;
     }
 
+    public function searchAfter(array $searchAfter): self
+    {
+        $this->request['search_after'] = $searchAfter;
+        return $this;
+    }
+
+    public function pit(array $pit): self
+    {
+        $this->request['pit'] = $pit;
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->request;

--- a/tests/Unit/Search/SearchRequestTest.php
+++ b/tests/Unit/Search/SearchRequestTest.php
@@ -394,4 +394,42 @@ final class SearchRequestTest extends TestCase
             'min_score' => 0.5,
         ], $request->toArray());
     }
+
+    public function test_array_casting_with_search_after(): void
+    {
+        $request = new SearchRequest([
+            'match_all' => new stdClass(),
+        ]);
+
+        $request->searchAfter(['1624169819000']);
+
+        $this->assertEquals([
+            'query' => [
+                'match_all' => new stdClass(),
+            ],
+            'search_after' => ['1624169819000'],
+        ], $request->toArray());
+    }
+
+    public function test_array_casting_with_pit(): void
+    {
+        $request = new SearchRequest([
+            'match_all' => new stdClass(),
+        ]);
+
+        $request->pit([
+            'id' => '<pit_id>',
+            'keep_alive' => '1m',
+        ]);
+
+        $this->assertEquals([
+            'query' => [
+                'match_all' => new stdClass(),
+            ],
+            'pit' => [
+                'id' => '<pit_id>',
+                'keep_alive' => '1m',
+            ],
+        ], $request->toArray());
+    }
 }


### PR DESCRIPTION
This pull request adds `search_after` and `pit` options to `SearchRequest`. 

When the amount of results is larger than elasticsearch's results window, the `from` parameter cannot be used. It is recommended to use [the `search_after` parameter instead](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after). This PR enables that functionality.

This update is required to enable the same functionality in babenkoivan/elastic-scout-driver-plus. See https://github.com/babenkoivan/elastic-scout-driver-plus/pull/94