### PR TITLE
The key of a bucket can have different types

### DIFF
--- a/src/Search/Bucket.php
+++ b/src/Search/Bucket.php
@@ -19,7 +19,7 @@ final class Bucket implements RawResponseInterface
         return $this->bucket['doc_count'] ?? 0;
     }
 
-    public function key(): string
+    public function key(): mixed
     {
         return $this->bucket['key'];
     }


### PR DESCRIPTION
Like I said in the issue #19 the keys of buckets can be int and other types depending on the scheme of Elastic. I my case I did an aggregation to an id with the type integer. It is not possible to get the key of the bucket in the result without an PHP error. So I changed the type of the return value of the method "keys" (Bucket) from "string" to "mixed".