### PR TITLE
Add explain parameter

### DIFF
--- a/src/Search/SearchParameters.php
+++ b/src/Search/SearchParameters.php
@@ -146,6 +146,12 @@ final class SearchParameters implements Arrayable
         return $this;
     }
 
+    public function explain(bool $explain): self
+    {
+        $this->params['body']['explain'] = $explain;
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->params;

--- a/tests/Unit/Search/SearchParametersTest.php
+++ b/tests/Unit/Search/SearchParametersTest.php
@@ -383,4 +383,15 @@ final class SearchParametersTest extends TestCase
         $searchParameters = (new SearchParameters())->routing(['foo', 'bar']);
         $this->assertSame(['routing' => 'foo,bar'], $searchParameters->toArray());
     }
+
+    public function test_array_casting_with_explain(): void
+    {
+        $searchParameters = (new SearchParameters())->explain(true);
+
+        $this->assertEquals([
+            'body' => [
+                'explain' => true,
+            ],
+        ], $searchParameters->toArray());
+    }
 }


### PR DESCRIPTION
During development and for debugging queries, the `explain` parameter can be invaluable. Alternatively to these changes, the `final` could be removed from the `SearchParameters` class to allow extending it.