### PR TITLE
Add method to configure dynamic mapping on index

### DIFF
--- a/src/Indices/Mapping.php
+++ b/src/Indices/Mapping.php
@@ -91,7 +91,10 @@ final class Mapping implements Arrayable
         return $this;
     }
 
-    public function dynamic(mixed $dynamic): self
+    /**
+     * @param string|bool $dynamic
+     */
+    public function dynamic($dynamic): self
     {
         $this->dynamic = $dynamic;
 

--- a/src/Indices/Mapping.php
+++ b/src/Indices/Mapping.php
@@ -56,7 +56,10 @@ final class Mapping implements Arrayable
     private ?bool $isSourceEnabled;
     private MappingProperties $properties;
     private array $dynamicTemplates = [];
-    private mixed $dynamic;
+    /**
+     * @var string|bool|null
+     */
+    private $dynamic;
 
     public function __construct()
     {

--- a/src/Indices/Mapping.php
+++ b/src/Indices/Mapping.php
@@ -56,6 +56,7 @@ final class Mapping implements Arrayable
     private ?bool $isSourceEnabled;
     private MappingProperties $properties;
     private array $dynamicTemplates = [];
+    private mixed $dynamic;
 
     public function __construct()
     {
@@ -90,6 +91,13 @@ final class Mapping implements Arrayable
         return $this;
     }
 
+    public function dynamic(mixed $dynamic): self
+    {
+        $this->dynamic = $dynamic;
+
+        return $this;
+    }
+
     public function dynamicTemplate(string $name, array $parameters): self
     {
         $this->dynamicTemplates[] = [$name => $parameters];
@@ -117,6 +125,10 @@ final class Mapping implements Arrayable
             $mapping['_source'] = [
                 'enabled' => $this->isSourceEnabled,
             ];
+        }
+
+        if(isset($this->dynamic)) {
+            $mapping['dynamic'] = $this->dynamic;
         }
 
         if (!empty($properties)) {

--- a/tests/Unit/Indices/MappingTest.php
+++ b/tests/Unit/Indices/MappingTest.php
@@ -56,6 +56,15 @@ class MappingTest extends TestCase
         ], $mapping->toArray());
     }
 
+    public function test_dynamic_mapping_can_be_configured(): void
+    {
+        $mapping = (new Mapping())->dynamic('strict');
+
+        $this->assertSame([
+            'dynamic' => 'strict',
+        ], $mapping->toArray());
+    }
+
     public function test_default_array_casting(): void
     {
         $this->assertSame([], (new Mapping())->toArray());


### PR DESCRIPTION
This PR would allow you to easily configure the [`dynamic` property](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/dynamic.html#dynamic) when defining the mapping for an index.
I'm not sure how to add support for nested properties. I'm not familiar enough (right now) with this library. 
I can give it a try if you would like to add support for configuring this directly over using raw mappings. :v: