### PR TITLE
Fix implicitly nullable parameter declarations in PHP 8.4

### DIFF
--- a/src/Documents/Document.php
+++ b/src/Documents/Document.php
@@ -24,7 +24,7 @@ final class Document implements Arrayable
     /**
      * @return mixed
      */
-    public function content(string $key = null)
+    public function content(?string $key = null)
     {
         return Arr::get($this->content, $key);
     }

--- a/src/Documents/DocumentManager.php
+++ b/src/Documents/DocumentManager.php
@@ -20,7 +20,7 @@ class DocumentManager
         string $indexName,
         Collection $documents,
         bool $refresh = false,
-        Routing $routing = null
+        ?Routing $routing = null
     ): self {
         $params = [
             'index' => $indexName,
@@ -57,7 +57,7 @@ class DocumentManager
         string $indexName,
         array $documentIds,
         bool $refresh = false,
-        Routing $routing = null
+        ?Routing $routing = null
     ): self {
         $params = [
             'index' => $indexName,

--- a/src/Indices/Index.php
+++ b/src/Indices/Index.php
@@ -8,7 +8,7 @@ final class Index
     private ?Mapping $mapping;
     private ?Settings $settings;
 
-    public function __construct(string $name, Mapping $mapping = null, Settings $settings = null)
+    public function __construct(string $name, ?Mapping $mapping = null, ?Settings $settings = null)
     {
         $this->name = $name;
         $this->mapping = $mapping;


### PR DESCRIPTION
See: <https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated>

use [rector](https://github.com/rectorphp/rector) auto fix:

rules:

- ExplicitNullableParamTypeRector