### PR TITLE
Add runtimeMappings and fields support to SearchParameters (with tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,21 @@ $searchParameters->scriptFields([
     ],
 ]);
 
+// runtime mappings
+$searchParameters->runtimeMappings([
+    'day_of_week' => [
+        'type' => 'long',
+        'script' => [
+            'lang' => 'painless',
+            'source' => 'doc[params.field] * params.multiplier',
+            'params' => [
+                'field' => 'my_field',
+                'multiplier' => 2,
+            ],
+        ],
+    ],
+]);
+
 // boost indices
 $searchParameters->indicesBoost([
     ['my-alias' => 1.4],

--- a/src/Search/SearchParameters.php
+++ b/src/Search/SearchParameters.php
@@ -116,6 +116,18 @@ final class SearchParameters implements Arrayable
         return $this;
     }
 
+    public function runtimeMappings(array $runtimeFields): self
+    {
+        $this->params['body']['runtime_mappings'] = $runtimeFields;
+        return $this;
+    }
+
+    public function fields(array $fields): self
+    {
+        $this->params['body']['fields'] = $fields;
+        return $this;
+    }
+
     public function searchType(string $searchType): self
     {
         $this->params['search_type'] = $searchType;

--- a/tests/Unit/Search/SearchParametersTest.php
+++ b/tests/Unit/Search/SearchParametersTest.php
@@ -314,6 +314,41 @@ final class SearchParametersTest extends TestCase
         ], $searchParameters->toArray());
     }
 
+    public function test_array_casting_with_runtime_mappings(): void
+    {
+        $searchParameters = (new SearchParameters())->runtimeMappings([
+            'day_of_week' => [
+                'type' => 'long',
+                'script' => [
+                    'lang' => 'painless',
+                    'source' => 'doc[params.field] * params.multiplier',
+                    'params' => [
+                        'field' => 'my_field',
+                        'multiplier' => 2,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            'body' => [
+                'runtime_mappings' => [
+                    'day_of_week' => [
+                        'type' => 'long',
+                        'script' => [
+                            'lang' => 'painless',
+                            'source' => 'doc[params.field] * params.multiplier',
+                            'params' => [
+                                'field' => 'my_field',
+                                'multiplier' => 2,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $searchParameters->toArray());
+    }
+
     public function test_array_casting_with_min_score(): void
     {
         $searchParameters = (new SearchParameters())->minScore(0.5);
@@ -321,6 +356,17 @@ final class SearchParametersTest extends TestCase
         $this->assertEquals([
             'body' => [
                 'min_score' => 0.5,
+            ],
+        ], $searchParameters->toArray());
+    }
+
+    public function test_array_casting_with_fields(): void
+    {
+        $searchParameters = (new SearchParameters())->fields(['my_field']);
+
+        $this->assertEquals([
+            'body' => [
+                'fields' => ['my_field'],
             ],
         ], $searchParameters->toArray());
     }


### PR DESCRIPTION
## Summary

This PR extends `SearchParameters` with two new builder methods—`runtimeMappings()` and `fields()`—and adds PHPUnit coverage to validate their behavior.